### PR TITLE
Reduce memory allocation in callers

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -59,8 +59,8 @@ func callers(depth int) *stack {
 	var pcs [maxDepth]uintptr
 
 	n := runtime.Callers(2+depth, pcs[:])
-
-	var st stack = pcs[0:n]
+	st := make(stack, n)
+	copy(st, pcs[:n])
 
 	return &st
 }


### PR DESCRIPTION
This fixes issue #27 by ensuring that `pcs` array allocated on stack
does not escape to heap. See issue[1] for details.

[1]: https://github.com/emperror/errors/issues/27

Signed-off-by: Sunil Thaha <sthaha@redhat.com>